### PR TITLE
 feat: implement the Co-interior Pairs calculator #609

### DIFF
--- a/calculators/src/mathematical/coInteriorPairs/MainCoInteriorPairs.js
+++ b/calculators/src/mathematical/coInteriorPairs/MainCoInteriorPairs.js
@@ -1,19 +1,44 @@
-import React from 'react';
-import { Container, Typography } from '@mui/material';
+import React, { useState } from "react";
+import { Container, Typography, TextField, Button, Box } from "@mui/material";
 
 function MainCoInteriorPairs(){
-    return(
-        <Container maxWidth="lg" sx={{ bgcolor: '#eeeeee', minHeight: '90vh', paddingY:"10" }}>
-            <Typography pt={1} variant='h5' sx = {{textAlign: "center"}}>Co-Interior Pairs Calculator</Typography>
-            <hr/>
-            <br/>
-            {/* Write your code here */}
+  const [angle, setAngle] = useState("");
+  const [result, setResult] = useState(null);
 
+  const handleCalculate = () => {
+    // Assuming the sum of co-interior angles is always 180 degrees
+    const otherAngle = 180 - parseFloat(angle);
+    setResult(otherAngle.toFixed(2)); 
+  };
+  return(
+    <Container maxWidth="lg" sx={{ bgcolor: "#eeeeee", minHeight: "90vh", paddingY: "10" }}>
+      <Typography pt={1} variant="h5" sx={{ textAlign: "center" }}> Co-Interior Pairs Calculator </Typography>
+      <hr />
+      <br />
+      {/* Write your code here */}
 
+      <TextField
+        label="Enter first Angle"
+        fullWidth
+        value={angle}
+        onChange={(e) => setAngle(e.target.value)}
+        type="number"
+        inputProps={{ step: "any" }}
+      />
 
-            {/* End your code here */}
-        </Container>
-    )
+      <Button variant="contained" color="primary" onClick={handleCalculate}>
+        Calculate
+      </Button>
+
+      {result !== null && (
+        <Box mt={2}>
+          <Typography>Second Angle: {result}°</Typography>
+        </Box>
+      )}
+
+      {/* End your code here */}
+    </Container>
+  );
 }
 
 export default MainCoInteriorPairs;


### PR DESCRIPTION
### Issue Id you have worked upon - 
#609 

### Briefly explain your program logic - 
- Added Co-Interior Angle calculation based on the sum of 180 degrees. 
- The calculateCoInteriorAngle function takes one angle and computes the other.
- It uses parseFloat and sets the result to two decimal places with toFixed(2)

### Screenshots(Attach 2 screenshots of your own input and output) - 
Attach here
![image](https://github.com/SarthakKeshari/calc_for_everything/assets/83615352/c37a2ac2-67da-44a6-9309-80da147a7125)


<br>


### By raising this PR I affirm that -
- [x] My code follows the guidelines of this project.<br>
- [x] I have performed a self-review of my own code.<br>
- [x] I have commented my code.<br>
- [x] My code gives the correct output.<br>

- [x] I affirm that I strictly follow contributing guidelines and code of conduct.
